### PR TITLE
Put large assets in separate assetbundles to avoid bundles > 4GB

### DIFF
--- a/Mapify/Map/MapLifeCycle.cs
+++ b/Mapify/Map/MapLifeCycle.cs
@@ -81,6 +81,7 @@ namespace Mapify.Map
 
             scenes = scenesReq.assetBundle;
 
+            //todo put mapinfo in its own assetbundle so we don't have to search though all of them to find it.
             // Register MapInfo
             MapInfo mapInfo = null;
             foreach (var ass in assets_assetBundles)

--- a/Mapify/Map/Maps.cs
+++ b/Mapify/Map/Maps.cs
@@ -126,5 +126,11 @@ namespace Mapify.Map
         {
             return Path.Combine(mapDir ?? availableMaps[LoadedMap.name].Item3, fileName);
         }
+
+        public static string[] GetMapAssets(string searchPattern, string mapDir = null)
+        {
+            string path = mapDir ?? availableMaps[LoadedMap.name].Item3;
+            return Directory.GetFiles(path, searchPattern);
+        }
     }
 }

--- a/MapifyEditor/Export/MapExporter.cs
+++ b/MapifyEditor/Export/MapExporter.cs
@@ -217,7 +217,7 @@ namespace Mapify.Editor
 
                     string[] pathArray = { assetPaths[i] };
                     builds.Add(new AssetBundleBuild {
-                        assetBundleName = Names.ASSETS_ASSET_BUNDLES_PREFIX+Path.GetFileName(absolutePath),
+                        assetBundleName = Names.ASSETS_ASSET_BUNDLES_PREFIX+'_'+Path.GetFileName(absolutePath),
                         assetNames = pathArray
                     });
 

--- a/MapifyEditor/Export/MapExporter.cs
+++ b/MapifyEditor/Export/MapExporter.cs
@@ -173,6 +173,8 @@ namespace Mapify.Editor
             List<string> assetPaths = new List<string>(allAssetPaths.Length - builds.Count);
             List<string> scenePaths = new List<string>();
 
+            var mapInfoPath = AssetDatabase.GetAssetPath(EditorAssets.FindAsset<MapInfo>());
+
             for (var i = 0; i < allAssetPaths.Length; i++)
             {
                 var assetPath = allAssetPaths[i];
@@ -188,7 +190,7 @@ namespace Mapify.Editor
                 {
                     scenePaths.Add(assetPath);
                 }
-                else if (assetPath.Contains("MapInfo.asset")) //todo the docs say "The name doesn't matter". Is there another way to find the MapInfo?
+                else if (assetPath == mapInfoPath)
                 {
                     CreateMapInfoBuild(assetPath, ref builds);
                 }

--- a/MapifyEditor/Names.cs
+++ b/MapifyEditor/Names.cs
@@ -3,7 +3,7 @@ namespace Mapify.Editor
     public static class Names
     {
         public const string DEFAULT_MAP_NAME = "Default";
-        public const string ASSETS_ASSET_BUNDLES_PREFIX = "assets_";
+        public const string ASSETS_ASSET_BUNDLES_PREFIX = "assets";
         public const string SCENES_ASSET_BUNDLE = "scenes";
         public const string MAP_INFO_FILE = "mapInfo.json";
         public const string MOD_INFO_FILE = "info.json";

--- a/MapifyEditor/Names.cs
+++ b/MapifyEditor/Names.cs
@@ -3,7 +3,7 @@ namespace Mapify.Editor
     public static class Names
     {
         public const string DEFAULT_MAP_NAME = "Default";
-        public const string ASSETS_ASSET_BUNDLE = "assets";
+        public const string ASSETS_ASSET_BUNDLES_PREFIX = "assets_";
         public const string SCENES_ASSET_BUNDLE = "scenes";
         public const string MAP_INFO_FILE = "mapInfo.json";
         public const string MOD_INFO_FILE = "info.json";

--- a/MapifyEditor/Names.cs
+++ b/MapifyEditor/Names.cs
@@ -5,6 +5,7 @@ namespace Mapify.Editor
         public const string DEFAULT_MAP_NAME = "Default";
         public const string ASSETS_ASSET_BUNDLES_PREFIX = "assets";
         public const string SCENES_ASSET_BUNDLE = "scenes";
+        public const string MAP_INFO_ASSET_BUNDLE = "mapInfo";
         public const string MAP_INFO_FILE = "mapInfo.json";
         public const string MOD_INFO_FILE = "info.json";
         public const string MAPIFY_VERSION_FILE = "Assets/Mapify/version.txt";


### PR DESCRIPTION
Currently, Mapify puts all assets from the `Assets` folder in 1 big assetbundle. This leads to an error with large assets because Unity cannot load asset bundles larger then 4GB.
```
Serialized files over 4.00 GB (4294967295 bytes) cannot be loaded by the player. Some likely ways to reduce this are utilizing asset bundles, re-balancing asset locations, or limiting their serialized size e.g. limiting the maximum texture sizes.
```
This commit changes the exporter to put each asset file > 500MB in it's own asset bundle, which 'solves' this. Users will still need to split large assets (>4GB) up into multiple files, but now the `Assets` can be large.