### PR TITLE
Show station names on world map instead of station ID

### DIFF
--- a/Mapify/Map/Maps.cs
+++ b/Mapify/Map/Maps.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using DV;
 using Mapify.Editor;
+using Mapify.SceneInitializers.GameContent;
 using UnityEngine;
 using UnityModManagerNet;
 
@@ -112,6 +113,7 @@ namespace Mapify.Map
 
         public static void RegisterLoadedMap(MapInfo mapInfo)
         {
+            WorldMapSetup.showStationNamesOnMap = mapInfo.showStationNamesOnMap;
             IsDefaultMap = mapInfo.name == DEFAULT_MAP_INFO.name;
             LoadedMap = mapInfo;
         }

--- a/Mapify/SceneInitializers/GameContent/WorldMapSetup.cs
+++ b/Mapify/SceneInitializers/GameContent/WorldMapSetup.cs
@@ -16,7 +16,7 @@ namespace Mapify.SceneInitializers.GameContent
     {
         private static bool modifiedMaterial;
         private static Texture defaultTexture;
-        public static bool showStationNamesOnMap = false;
+        public static bool showStationNamesOnMap;
 
         public override void Run()
         {
@@ -109,14 +109,7 @@ namespace Mapify.SceneInitializers.GameContent
                 TMP_Text tmp = name.GetComponent<TMP_Text>();
                 tmp.rectTransform.localPosition = station.YardCenter.position.ToXZ().Scale(0, Maps.LoadedMap.worldSize, -0.175f, 0.175f);
 
-                if (showStationNamesOnMap)
-                {
-                    tmp.text = station.stationName;
-                }
-                else
-                {
-                    tmp.text = station.stationID;
-                }
+                tmp.text = showStationNamesOnMap ? station.stationName : station.stationID;
             }
 
             Object.Destroy(namePrefab);

--- a/Mapify/SceneInitializers/GameContent/WorldMapSetup.cs
+++ b/Mapify/SceneInitializers/GameContent/WorldMapSetup.cs
@@ -16,6 +16,7 @@ namespace Mapify.SceneInitializers.GameContent
     {
         private static bool modifiedMaterial;
         private static Texture defaultTexture;
+        public static bool showStationNamesOnMap = false;
 
         public override void Run()
         {
@@ -107,7 +108,15 @@ namespace Mapify.SceneInitializers.GameContent
                 GameObject name = Object.Instantiate(namePrefab, names);
                 TMP_Text tmp = name.GetComponent<TMP_Text>();
                 tmp.rectTransform.localPosition = station.YardCenter.position.ToXZ().Scale(0, Maps.LoadedMap.worldSize, -0.175f, 0.175f);
-                tmp.text = station.stationName;
+
+                if (showStationNamesOnMap)
+                {
+                    tmp.text = station.stationName;
+                }
+                else
+                {
+                    tmp.text = station.stationID;
+                }
             }
 
             Object.Destroy(namePrefab);

--- a/Mapify/SceneInitializers/GameContent/WorldMapSetup.cs
+++ b/Mapify/SceneInitializers/GameContent/WorldMapSetup.cs
@@ -107,7 +107,7 @@ namespace Mapify.SceneInitializers.GameContent
                 GameObject name = Object.Instantiate(namePrefab, names);
                 TMP_Text tmp = name.GetComponent<TMP_Text>();
                 tmp.rectTransform.localPosition = station.YardCenter.position.ToXZ().Scale(0, Maps.LoadedMap.worldSize, -0.175f, 0.175f);
-                tmp.text = station.stationID;
+                tmp.text = station.stationName;
             }
 
             Object.Destroy(namePrefab);

--- a/MapifyEditor/MapInfo.cs
+++ b/MapifyEditor/MapInfo.cs
@@ -64,6 +64,9 @@ namespace Mapify.Editor
             }
         };
 
+        [Tooltip("Show the names of stations on the map instead of the station IDs")]
+        public bool showStationNamesOnMap = false;
+
         [Header("Terrain Streaming")]
         [Tooltip("How many terrain chunks to keep loaded around the player")]
         public byte terrainLoadingRingSize = 2;

--- a/MapifyEditor/MapInfo.cs
+++ b/MapifyEditor/MapInfo.cs
@@ -65,7 +65,7 @@ namespace Mapify.Editor
         };
 
         [Tooltip("Show the names of stations on the map instead of the station IDs")]
-        public bool showStationNamesOnMap = false;
+        public bool showStationNamesOnMap;
 
         [Header("Terrain Streaming")]
         [Tooltip("How many terrain chunks to keep loaded around the player")]


### PR DESCRIPTION
In the base map, station names are shown on the world map. But in Mapify maps the station ID is shown instead. This PR fixes that.