### PR TITLE
Optionally use an image as map instead of rendering terrain

### DIFF
--- a/MapifyEditor/Export/BuildUpdaters/Terrain/TerrainSceneUpdater.cs
+++ b/MapifyEditor/Export/BuildUpdaters/Terrain/TerrainSceneUpdater.cs
@@ -9,11 +9,20 @@ namespace Mapify.Editor.StateUpdaters
     {
         protected override void Update(Scenes scenes)
         {
-            Terrain[] sortedTerrain = scenes.terrainScene.GetAllComponents<Terrain>()
-                .Where(terrain => terrain.gameObject.activeInHierarchy)
-                .ToArray()
-                .Sort();
-            MapRenderer.RenderMap(sortedTerrain);
+            MapInfo mapInfo = EditorAssets.FindAsset<MapInfo>();
+
+            if (mapInfo.useFixedMapImage)
+            {
+                MapRenderer.RenderMapFromImage(mapInfo);
+            }
+            else
+            {
+                Terrain[] sortedTerrain = scenes.terrainScene.GetAllComponents<Terrain>()
+                    .Where(terrain => terrain.gameObject.activeInHierarchy)
+                    .ToArray()
+                    .Sort();
+                MapRenderer.RenderMapFromTerrain(sortedTerrain, mapInfo);
+            }
         }
     }
 }

--- a/MapifyEditor/Export/Validators/Project/MapInfoValidator.cs
+++ b/MapifyEditor/Export/Validators/Project/MapInfoValidator.cs
@@ -42,6 +42,18 @@ namespace MapifyEditor.Export.Validators.Project
                 yield return Result.Error($"The spawn position's Y value must be above the terrain ({worldHeight})", mapInfo);
             if (spawnPos.y < mapInfo.waterLevel)
                 yield return Result.Error($"The spawn position must be above the water level ({mapInfo.waterLevel}", mapInfo);
+
+            if (mapInfo.useFixedMapImage)
+            {
+                if (mapInfo.fixedMapImage == null)
+                {
+                    yield return Result.Error("Mapinfo 'fixedMapImage' must be set when 'useFixedMapImage' is true", mapInfo);
+                }
+                else if(mapInfo.fixedMapImage.width != mapInfo.fixedMapImage.height)
+                {
+                    yield return Result.Warning($"Mapinfo 'fixedMapImage' should be square or it will be stretched. Current dimensions: {mapInfo.fixedMapImage.width}x{mapInfo.fixedMapImage.height}", mapInfo);
+                }
+            }
         }
     }
 }

--- a/MapifyEditor/Export/Validators/Project/MapInfoValidator.cs
+++ b/MapifyEditor/Export/Validators/Project/MapInfoValidator.cs
@@ -47,11 +47,11 @@ namespace MapifyEditor.Export.Validators.Project
             {
                 if (mapInfo.fixedMapImage == null)
                 {
-                    yield return Result.Error("Mapinfo 'fixedMapImage' must be set when 'useFixedMapImage' is true", mapInfo);
+                    yield return Result.Error($"MapInfo: '{nameof(MapInfo.fixedMapImage)}' must be set when '{nameof(MapInfo.useFixedMapImage)}' is true", mapInfo);
                 }
                 else if(mapInfo.fixedMapImage.width != mapInfo.fixedMapImage.height)
                 {
-                    yield return Result.Warning($"Mapinfo 'fixedMapImage' should be square or it will be stretched. Current dimensions: {mapInfo.fixedMapImage.width}x{mapInfo.fixedMapImage.height}", mapInfo);
+                    yield return Result.Warning($"MapInfo: '{nameof(MapInfo.fixedMapImage)}' should be square or it will be stretched. Current dimensions: {mapInfo.fixedMapImage.width}x{mapInfo.fixedMapImage.height}", mapInfo);
                 }
             }
         }

--- a/MapifyEditor/MapInfo.cs
+++ b/MapifyEditor/MapInfo.cs
@@ -31,6 +31,10 @@ namespace Mapify.Editor
         public float worldBoundaryMargin = 5.0f;
 
         [Header("Procedural Maps")]
+        [Tooltip("Use an image as map instead of rendering the terrain on the map")]
+        public bool useFixedMapImage = false;
+        [Tooltip("If useFixedMapImage is true, this image will be the map")]
+        public Texture2D fixedMapImage = null;
         [Tooltip("How large tracks should be on the map")]
         public float trackWidth = 5;
         [Tooltip("The color of tracks on the map")]

--- a/MapifyEditor/Procedural/MapRenderer.cs
+++ b/MapifyEditor/Procedural/MapRenderer.cs
@@ -9,9 +9,8 @@ namespace Mapify.Editor
     {
         private const int TEXTURE_SIZE = 2048;
 
-        public static void RenderMap(Terrain[] terrains)
+        public static void RenderMapFromTerrain(Terrain[] terrains, MapInfo mapInfo)
         {
-            MapInfo mapInfo = EditorAssets.FindAsset<MapInfo>();
             Texture2D combinedHeightmap = CreateHeightmap(terrains, mapInfo);
             Texture2D scaledHeightmap = Resize(combinedHeightmap, TEXTURE_SIZE, TEXTURE_SIZE);
             mapInfo.mapTextureSerialized = scaledHeightmap.EncodeToJPG();
@@ -79,6 +78,13 @@ namespace Mapify.Editor
 
             RenderTexture.ReleaseTemporary(rt);
             return result;
+        }
+
+        public static void RenderMapFromImage(MapInfo mapInfo)
+        {
+            Texture2D scaledMapImage = Resize(mapInfo.fixedMapImage, TEXTURE_SIZE, TEXTURE_SIZE);
+            mapInfo.mapTextureSerialized = scaledMapImage.EncodeToJPG();
+            mapInfo.mapTextureSize = new[] { scaledMapImage.width, scaledMapImage.height };
         }
     }
 }


### PR DESCRIPTION
This is useful for custom maps that don't use the terrain scene or to make prettier maps.