### PR TITLE
Simplify SingletonBehaviour access

### DIFF
--- a/Mapify/Patches/DisplayLoadingInfoPatch.cs
+++ b/Mapify/Patches/DisplayLoadingInfoPatch.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using DV.Utils;
 using HarmonyLib;
 using TMPro;
 
@@ -57,7 +56,7 @@ namespace Mapify.Patches
 
             if (!Bootstrap.bootstrapped)
                 return false;
-            SingletonBehaviour<LoadingScreenManager>.Instance.UpdateProgress(percentageLoaded / 100f);
+            LoadingScreenManager.Instance.UpdateProgress(percentageLoaded / 100f);
             return false;
         }
     }

--- a/Mapify/Patches/ItemDisablerGridPatch.cs
+++ b/Mapify/Patches/ItemDisablerGridPatch.cs
@@ -1,6 +1,5 @@
 using DV;
 using DV.TerrainSystem;
-using DV.Utils;
 using HarmonyLib;
 using Mapify.Map;
 using UnityEngine;
@@ -31,7 +30,7 @@ namespace Mapify.Patches
                 return false;
             }
 
-            __result = SingletonBehaviour<TerrainGrid>.Instance.IsInLoadedRegion(worldPos);
+            __result = TerrainGrid.Instance.IsInLoadedRegion(worldPos);
             return false;
         }
     }

--- a/Mapify/Patches/MainMenuControllerPatch.cs
+++ b/Mapify/Patches/MainMenuControllerPatch.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using DV.UI;
 using DV.UI.PresetEditors;
-using DV.Utils;
 using HarmonyLib;
 using Mapify.Editor;
 using Mapify.Utils;
@@ -19,7 +18,7 @@ namespace Mapify.Patches
 
         private static void OnStartNewGameRequested(UIStartGameData data)
         {
-            SingletonBehaviour<CoroutineManager>.Instance.StartCoroutine(DataWaiter());
+            CoroutineManager.Instance.StartCoroutine(DataWaiter());
         }
 
         private static IEnumerator DataWaiter()

--- a/Mapify/Patches/TutorialHelperPatch.cs
+++ b/Mapify/Patches/TutorialHelperPatch.cs
@@ -1,4 +1,3 @@
-using DV.Utils;
 using HarmonyLib;
 using Mapify.Map;
 
@@ -11,8 +10,8 @@ namespace Mapify.Patches
         {
             if (Maps.IsDefaultMap)
                 return true;
-            SingletonBehaviour<SaveGameManager>.Instance.data.SetBool("Tutorial_01_completed", true);
-            SingletonBehaviour<SaveGameManager>.Instance.data.SetBool("Tutorial_02_completed", true);
+            SaveGameManager.Instance.data.SetBool("Tutorial_01_completed", true);
+            SaveGameManager.Instance.data.SetBool("Tutorial_02_completed", true);
             return false;
         }
     }

--- a/Mapify/Patches/WorldStreamingInitPatch.cs
+++ b/Mapify/Patches/WorldStreamingInitPatch.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections;
 using AwesomeTechnologies.VegetationSystem;
-using DV.Utils;
 using HarmonyLib;
 using Mapify.Components;
 using Mapify.Editor;
@@ -23,7 +22,7 @@ namespace Mapify.Patches
 
         private static bool Prefix(WorldStreamingInit __instance)
         {
-            SaveGameManager saveGameManager = SingletonBehaviour<SaveGameManager>.Instance;
+            SaveGameManager saveGameManager = SaveGameManager.Instance;
             saveGameManager.FindStartGameData();
             BasicMapInfo basicMapInfo = saveGameManager.GetBasicMapInfo();
             if (basicMapInfo.IsDefault())
@@ -44,7 +43,7 @@ namespace Mapify.Patches
 
         private static IEnumerator WaitForLoadingScreen(BasicMapInfo basicMapInfo)
         {
-            WorldStreamingInit wsi = SingletonBehaviour<WorldStreamingInit>.Instance;
+            WorldStreamingInit wsi = WorldStreamingInit.Instance;
             yield return new WaitUntil(() => CanLoad);
             wsi.StartCoroutine(MapLifeCycle.LoadMap(basicMapInfo));
             yield return new WaitUntil(() => CanInitialize);


### PR DESCRIPTION
Accessing all SingletonBehaviours through the generic SingleTonBehaviour class is redundant, and make the code harder to read.