### PR TITLE
Bump minimum UMM version

### DIFF
--- a/MapifyEditor/Export/MapExporter.cs
+++ b/MapifyEditor/Export/MapExporter.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -321,7 +321,7 @@ namespace Mapify.Editor
                 Id = mapInfo.name,
                 Version = mapInfo.version,
                 DisplayName = mapInfo.name,
-                ManagerVersion = "0.27.3",
+                ManagerVersion = "0.27.13",
                 Requirements = new[] { "Mapify" },
                 HomePage = mapInfo.homePage
             };

--- a/info.json
+++ b/info.json
@@ -4,7 +4,7 @@
   "DisplayName": "Mapify",
   "Author": "Insprill",
   "EntryMethod": "Mapify.Mapify.Load",
-  "ManagerVersion": "0.27.3",
+  "ManagerVersion": "0.27.13",
   "HomePage": "https://www.nexusmods.com/derailvalley/mods/593",
   "Repository": "https://raw.githubusercontent.com/Insprill/dv-mapify/master/repository.json"
 }


### PR DESCRIPTION
0.27.13 fixed the bug where the MapInfo.json would be found before the Info.json when installing maps, causing them to be uninstallable