### PR TITLE
Documentation security update

### DIFF
--- a/Mapify/Settings.cs
+++ b/Mapify/Settings.cs
@@ -22,7 +22,7 @@ namespace Mapify
             if (ShowHiddenSettings)
             {
                 VerboseLogging = GUILayout.Toggle(VerboseLogging, "Verbose Logging");
-                ExtremelyVerboseLogging = GUILayout.Toggle(VerboseLogging, "Extremely Verbose Logging");
+                ExtremelyVerboseLogging = GUILayout.Toggle(ExtremelyVerboseLogging, "Extremely Verbose Logging");
             }
 
             #endregion

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,7 +14,7 @@ colorama==0.4.6
     # via mkdocs-material
 ghp-import==2.1.0
     # via mkdocs
-idna==3.4
+idna==3.7
     # via requests
 jinja2==3.1.2
     # via

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -16,7 +16,7 @@ ghp-import==2.1.0
     # via mkdocs
 idna==3.7
     # via requests
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   mkdocs
     #   mkdocs-material

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -58,7 +58,7 @@ requests==2.32.2
     # via mkdocs-material
 six==1.16.0
     # via python-dateutil
-urllib3==1.26.15
+urllib3==1.26.19
     # via requests
 watchdog==3.0.0
     # via mkdocs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile docs/requirements.in
 #
-certifi==2022.12.7
+certifi==2024.7.4
     # via requests
 charset-normalizer==3.1.0
     # via requests
@@ -31,10 +31,10 @@ mergedeep==1.3.4
     # via mkdocs
 mkdocs==1.4.2
     # via
-    #   -r docs/requirements.in
+    #   -r requirements.in
     #   mkdocs-material
 mkdocs-material==9.1.6
-    # via -r docs/requirements.in
+    # via -r requirements.in
 mkdocs-material-extensions==1.1.1
     # via mkdocs-material
 packaging==23.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -39,7 +39,7 @@ mkdocs-material-extensions==1.1.1
     # via mkdocs-material
 packaging==23.0
     # via mkdocs
-pygments==2.14.0
+pygments==2.15.0
     # via mkdocs-material
 pymdown-extensions==10.0
     # via mkdocs-material

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -41,7 +41,7 @@ packaging==23.0
     # via mkdocs
 pygments==2.14.0
     # via mkdocs-material
-pymdown-extensions==9.11
+pymdown-extensions==10.0
     # via mkdocs-material
 python-dateutil==2.8.2
     # via ghp-import

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -54,7 +54,7 @@ pyyaml-env-tag==0.1
     # via mkdocs
 regex==2023.3.23
     # via mkdocs-material
-requests==2.28.2
+requests==2.32.2
     # via mkdocs-material
 six==1.16.0
     # via python-dateutil


### PR DESCRIPTION
Fixes all of Dependabot's security warnings. 

I hosted this version of the docs locally and found no differences with the current version.