### PR TITLE
Vanilla asset fix

### DIFF
--- a/Mapify/AssetCopiers/GameContentCopier.cs
+++ b/Mapify/AssetCopiers/GameContentCopier.cs
@@ -39,7 +39,7 @@ namespace Mapify.SceneInitializers.Vanilla.GameContent
             yield return (VanillaAsset.CareerManager, GameObject.Instantiate(gameObject.FindChildByName("CareerManager")));
             yield return (VanillaAsset.JobValidator, GameObject.Instantiate(gameObject.FindChildByName("JobValidator")));
             yield return (VanillaAsset.TrashCan, GameObject.Instantiate(gameObject.FindChildByName("JobTrashBin")));
-            yield return (VanillaAsset.Dumpster, gameObject.FindChildByName("ItemDumpster"));
+            yield return (VanillaAsset.Dumpster, gameObject.FindChildByName("SkipDumpster"));
             yield return (VanillaAsset.LostAndFoundShed, gameObject.FindChildByName("OldShed"));
             yield return (VanillaAsset.WarehouseMachine, gameObject.FindChildByName("WarehouseMachineHMB"));
 

--- a/Mapify/SceneInitializers/GameContent/VanillaAssetSetup.cs
+++ b/Mapify/SceneInitializers/GameContent/VanillaAssetSetup.cs
@@ -11,30 +11,9 @@ namespace Mapify.SceneInitializers.GameContent
         {
             foreach (VanillaObject vanillaObject in Object.FindObjectsOfType<VanillaObject>())
             {
-                //only these belong in the gamecontent scene
-                switch (vanillaObject.asset)
-                {
-                    case VanillaAsset.CareerManager:
-                    case VanillaAsset.JobValidator:
-                    case VanillaAsset.TrashCan:
-                    case VanillaAsset.Dumpster:
-                    case VanillaAsset.LostAndFoundShed:
-                    case VanillaAsset.WarehouseMachine:
-                    case VanillaAsset.PlayerHouse:
-                    case VanillaAsset.PitStopStationCoal1:
-                    case VanillaAsset.PitStopStationCoal2:
-                    case VanillaAsset.PitStopStationWater1:
-                    case VanillaAsset.PitStopStationWater2:
-                    case VanillaAsset.StationOffice1:
-                    case VanillaAsset.StationOffice2:
-                    case VanillaAsset.StationOffice3:
-                    case VanillaAsset.StationOffice4:
-                    case VanillaAsset.StationOffice5:
-                    case VanillaAsset.StationOffice6:
-                    case VanillaAsset.StationOffice7:
-                        vanillaObject.Replace();
-                        break;
-                }
+                if (!vanillaObject.BelongsInGameContent()) continue;
+
+                vanillaObject.Replace();
             }
         }
     }

--- a/MapifyEditor/Export/Validators/VanillaAssetValidator.cs
+++ b/MapifyEditor/Export/Validators/VanillaAssetValidator.cs
@@ -1,0 +1,20 @@
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
+using Mapify.Editor.Utils;
+
+namespace Mapify.Editor.Validators
+{
+    public class VanillaAssetValidator : Validator
+    {
+        protected override IEnumerator<Result> Validate(Scenes scenes)
+        {
+            foreach (var vanillaObject in scenes.streamingScene.GetAllComponents<VanillaObject>())
+            {
+                if (!vanillaObject.BelongsInGameContent()) continue;
+
+                yield return Result.Error($"The vanilla asset {vanillaObject} needs to be in the {scenes.gameContentScene.name} scene", vanillaObject);
+            }
+        }
+    }
+}
+#endif

--- a/MapifyEditor/Vanilla/VanillaObject.cs
+++ b/MapifyEditor/Vanilla/VanillaObject.cs
@@ -7,5 +7,30 @@ namespace Mapify.Editor
         public VanillaAsset asset;
         public bool keepChildren = true;
         public Vector3 rotationOffset = Vector3.zero;
+
+        /// <summary>
+        /// Returns true if the VanillaAsset needs to be in the GameContent scene to work
+        /// </summary>
+        public bool BelongsInGameContent()
+        {
+            return asset == VanillaAsset.CareerManager ||
+                   asset == VanillaAsset.JobValidator ||
+                   asset == VanillaAsset.TrashCan ||
+                   asset == VanillaAsset.Dumpster ||
+                   asset == VanillaAsset.LostAndFoundShed ||
+                   asset == VanillaAsset.WarehouseMachine ||
+                   asset == VanillaAsset.PlayerHouse ||
+                   asset == VanillaAsset.PitStopStationCoal1 ||
+                   asset == VanillaAsset.PitStopStationCoal2 ||
+                   asset == VanillaAsset.PitStopStationWater1 ||
+                   asset == VanillaAsset.PitStopStationWater2 ||
+                   asset == VanillaAsset.StationOffice1 ||
+                   asset == VanillaAsset.StationOffice2 ||
+                   asset == VanillaAsset.StationOffice3 ||
+                   asset == VanillaAsset.StationOffice4 ||
+                   asset == VanillaAsset.StationOffice5 ||
+                   asset == VanillaAsset.StationOffice6 ||
+                   asset == VanillaAsset.StationOffice7;
+        }
     }
 }


### PR DESCRIPTION
The dumpster broke because the in-game name changed, this PR fixes it.  
I also discovered certain VanillaObjects don't work if you place them in the Streaming scene so I made a validator for that.